### PR TITLE
Bump Jackson version from 2.8.0 to 2.9.10.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,9 @@
 		<version.httpcomponents.httpcore>4.4.13</version.httpcomponents.httpcore>
 		<version.commons.io>2.5</version.commons.io>
 		<version.commons.codec>1.11</version.commons.codec>
-		<version.jackson>2.8.0</version.jackson>
+		<version.jackson.databind>2.9.10.7</version.jackson.databind>
+		<version.jackson.annotations>2.9.10</version.jackson.annotations>
+		<version.jackson.core>2.9.10</version.jackson.core>
 		<version.source.plugin>3.1.0</version.source.plugin>
 		<version.javadoc.plugin>3.1.0</version.javadoc.plugin>
 	</properties>
@@ -80,13 +82,19 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${version.jackson}</version>
+			<version>${version.jackson.databind}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>${version.jackson}</version>
+			<version>${version.jackson.annotations}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>${version.jackson.core}</version>
 		</dependency>
 
 	</dependencies>

--- a/src/main/java/com/documaster/rms/noark/ws/serialization/CustomObjectMapper.java
+++ b/src/main/java/com/documaster/rms/noark/ws/serialization/CustomObjectMapper.java
@@ -22,7 +22,8 @@ public enum CustomObjectMapper {
 		mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
 		mapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.ANY);
 		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+		mapper.setDefaultPropertyInclusion(
+				JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.ALWAYS));
 		mapper.setDateFormat(new SimpleDateFormat(CustomDateFormat.TIMESTAMP));
 
 		this.mapper = mapper;


### PR DESCRIPTION
Includes bug fixes.

Default configuration of ObjectMapper was changed to *not* serialize
properties with null values, i.e. a map entry with non-null key and null
value wouldn't be serialized by default. We, however, need to serialize
such properties, so the desired behaviour is implemented in our
ObjectMapper configuration.