### PR TITLE
Bump httpcomponens and commons-codec versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,11 @@
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<version.httpcomponents>4.5.3</version.httpcomponents>
+		<version.httpcomponents.fluent.hc>4.5.13</version.httpcomponents.fluent.hc>
+		<version.httpcomponents.httpclient>4.5.13</version.httpcomponents.httpclient>
+		<version.httpcomponents.httpcore>4.4.13</version.httpcomponents.httpcore>
 		<version.commons.io>2.5</version.commons.io>
+		<version.commons.codec>1.11</version.commons.codec>
 		<version.jackson>2.8.0</version.jackson>
 		<version.source.plugin>3.1.0</version.source.plugin>
 		<version.javadoc.plugin>3.1.0</version.javadoc.plugin>
@@ -47,13 +50,31 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>fluent-hc</artifactId>
-			<version>${version.httpcomponents}</version>
+			<version>${version.httpcomponents.fluent.hc}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>${version.httpcomponents.httpclient}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore</artifactId>
+			<version>${version.httpcomponents.httpcore}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>${version.commons.io}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>${version.commons.codec}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Includes bug fixes.

The versions of the following components are changed:
* fluent-hc: 4.5.3 -> 4.5.13;
* httpclient: 4.5.3 -> 4.5.13;
* httpcore: 4.4.6 -> 4.4.13;
* commons-codec: 1.9 -> 1.11.

Previously transitive dependencies are explicitly declared.