### PR TITLE
Configure Jackson's object mapper to work with the JVM time zone

### DIFF
--- a/src/main/java/com/documaster/rms/noark/ws/serialization/CustomObjectMapper.java
+++ b/src/main/java/com/documaster/rms/noark/ws/serialization/CustomObjectMapper.java
@@ -1,6 +1,7 @@
 package com.documaster.rms.noark.ws.serialization;
 
 import java.text.SimpleDateFormat;
+import java.util.TimeZone;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -25,6 +26,7 @@ public enum CustomObjectMapper {
 		mapper.setDefaultPropertyInclusion(
 				JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.ALWAYS));
 		mapper.setDateFormat(new SimpleDateFormat(CustomDateFormat.TIMESTAMP));
+		mapper.setTimeZone(TimeZone.getDefault());
 
 		this.mapper = mapper;
 	}


### PR DESCRIPTION
### Release Message for version 1.5.1
The Public Java Client is serializing and deserializing plain date fields (that is dates without time) improperly in some scenarios. Integrating parties that work with dates in UTC format were not affected by this and will not be affected by this fix.

For instance, if we, the client side, are in the CEST time zone (UTC +2) the date **2021-05-25 00:00:00 CEST** will get shifted to the UTC time zone equivalent, **2021-05-24 22:00:00 UTC**, and then that will be transformed to the text **2021-05-24** and sent to Documaster Archive. On the other hand, when Documaster Archive sends a date like **2021-05-24** the client will translate it to **2021-05-24 02:00:00 CEST**. Depending on the time zone of the client executing system, date shifts can occur in the following ways:
* A date can be stored in Documaster Archive with a day earlier than the intended one. For instance, the client wants to save the date **2021-05-25**, but actually in Documaster Archive it will be saved as **2021-05-24**.
* A date can be stored in Documaster Archive with a day later than the intended one. For instance, the client wants to save the date **2021-05-25**, but actually in Documaster Archive it will be saved as **2021-05-26**.
* A proper date can be fetched from Documaster Archive, but it can get further shifted to a date that is a day earlier than the originally received one. For instance, the client fetches the date **2021-05-25** as stored in Documaster Archive, but eventually in the Java client code it will be working with a date of **2021-05-24**.

Date fields that exhibit this behaviour are:
* Series Start Date (_arkivperiodeStartDato_) for Series
* Series End Date (_arkivperiodeSluttDato_) for Series
* Case Date (_saksdato_) for Case Files
* Meeting Date (_moetedato_) for Meeting Folders
* Record Date (_registreringsDato_) for all types of Records
* Document Date (_dokumentetsDato_) for all types of Records
* Due Date (_forfallsdato_) for all types of Records
* Public Access Assessment Date (_offentlighetsvurdertDato_) for Registry Entries

### Technical Background of the Issue
Without any configuration Jackson falls back to work with a UTC-based
time correction mechanism. While this won't affect date time fields, it
does get in the way when we are working with date-only fields.
Previously, before serialization each date would be translated to its
UTC bound equivalent which, depending on the time zone of the JVM, could
potentially shift the date to a day earlier. A similar bug can occur on
deserialization.