### PR TITLE
Expose the record responsible fields for all record types

### DIFF
--- a/src/main/java/com/documaster/rms/noark/ws/noarkentities/Journalpost.java
+++ b/src/main/java/com/documaster/rms/noark/ws/noarkentities/Journalpost.java
@@ -23,8 +23,6 @@ public class Journalpost extends RegistreringBase<Journalpost> {
 	private Integer journalaar;
 	private Integer journalsekvensnummer;
 	private Integer journalpostnummer;
-	private String journalansvarlig;
-	private String journalansvarligBrukerIdent;
 	private Boolean skjermKorrespondanseParterEInnsyn;
 
 	@JsonSerialize(using = NoarkEnumJsonSerializer.class)
@@ -81,26 +79,6 @@ public class Journalpost extends RegistreringBase<Journalpost> {
 	public void setJournalpostnummer(Integer journalpostnummer) {
 
 		this.journalpostnummer = journalpostnummer;
-	}
-
-	public String getJournalansvarlig() {
-
-		return journalansvarlig;
-	}
-
-	public void setJournalansvarlig(String journalansvarlig) {
-
-		this.journalansvarlig = journalansvarlig;
-	}
-
-	public String getJournalansvarligBrukerIdent() {
-
-		return journalansvarligBrukerIdent;
-	}
-
-	public void setJournalansvarligBrukerIdent(String journalansvarligBrukerIdent) {
-
-		this.journalansvarligBrukerIdent = journalansvarligBrukerIdent;
 	}
 
 	public Journalposttype getJournalposttype() {

--- a/src/main/java/com/documaster/rms/noark/ws/noarkentities/RegistreringBase.java
+++ b/src/main/java/com/documaster/rms/noark/ws/noarkentities/RegistreringBase.java
@@ -50,6 +50,10 @@ public abstract class RegistreringBase<TEntity extends RegistreringBase<TEntity>
 	private boolean serializeBeskrivelse;
 	private String forfatter;
 	private boolean serializeForfatter;
+	private String journalansvarlig;
+	private boolean serializeJournalansvarlig;
+	private String journalansvarligBrukerIdent;
+	private boolean serializeJournalansvarligBrukerIdent;
 	private BsmGroupsMap virksomhetsspesifikkeMetadata = new BsmGroupsMap();
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = CustomDateFormat.DATE)
@@ -183,6 +187,52 @@ public abstract class RegistreringBase<TEntity extends RegistreringBase<TEntity>
 		if (serializeForfatter) {
 
 			return Optional.ofNullable(forfatter);
+		}
+
+		return null;
+	}
+
+	public String getJournalansvarlig() {
+
+		return journalansvarlig;
+	}
+
+	@JsonProperty("journalansvarlig")
+	public void setJournalansvarlig(String journalansvarlig) {
+
+		this.journalansvarlig = journalansvarlig;
+		serializeJournalansvarlig = true;
+	}
+
+	@JsonProperty("journalansvarlig")
+	public Optional<String> getJournalansvarligAsOptional() {
+
+		if (serializeJournalansvarlig) {
+
+			return Optional.ofNullable(journalansvarlig);
+		}
+
+		return null;
+	}
+
+	public String getJournalansvarligBrukerIdent() {
+
+		return journalansvarligBrukerIdent;
+	}
+
+	@JsonProperty("journalansvarligBrukerIdent")
+	public void setJournalansvarligBrukerIdent(String journalansvarligBrukerIdent) {
+
+		this.journalansvarligBrukerIdent = journalansvarligBrukerIdent;
+		serializeJournalansvarligBrukerIdent = true;
+	}
+
+	@JsonProperty("journalansvarligBrukerIdent")
+	public Optional<String> getJournalansvarligBrukerIdentAsOptional() {
+
+		if (serializeJournalansvarligBrukerIdent) {
+
+			return Optional.ofNullable(journalansvarligBrukerIdent);
 		}
 
 		return null;


### PR DESCRIPTION
Since record responsible (journalansvarlig) and record responsible userid (journalansvarligBrukerIdent) are not required for all the other record types, we've made them nullable.